### PR TITLE
with-html-form: do not use fieldset

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,12 @@
  ChangeLog
 ===========
 
+0.8 (2018-05-04)
+================
+
+* Do not use ``fieldset`` in ``with-html-form``. It usually draws a box
+  around the form elements and this isn't always wanted.
+
 0.7.1 (2018-02-10)
 ==================
 

--- a/src/form.lisp
+++ b/src/form.lisp
@@ -49,7 +49,7 @@
                                             ""
                                             ;; (weblocks::session-name-string-pair)
                                             )))
-                (:fieldset
+                (:span
                  ,@body
                  (:input :name *action-string* :type "hidden" :value ,action-code))))
        ;; TODO: may be return log-from into the Weblocks


### PR DESCRIPTION
fieldset draws a box around the elements and this isn't always wanted.

https://www.w3schools.com/tags/tag_fieldset.asp

> The fieldset tag draws a box around the related elements.

In fact this renders badly in my app:

![selection_227](https://user-images.githubusercontent.com/3721004/38904394-71307bde-42aa-11e8-8fcd-0b952d0346e5.png)

VS

![selection_228](https://user-images.githubusercontent.com/3721004/38904396-737449e8-42aa-11e8-86f3-93db3ba49927.png)

I use the macro like this

           (with-html-form (:POST #'query)
             (:div :class "ui action input"
              (:input :type "text"
                      :name "query"
                      :class "ui input"
                      :placeholder "search...")
              (:input :type "submit"
                      :value "Search")))

and 

                  (with-html-form (:POST #'add-book)
                    (:input :type "hidden"
                            :name "index"
                            :value (position it results))
                    (:input :type "submit"
                            :class "ui primary button"
                            :value "add-book")))))))))))))

Cheers !