### PR TITLE
Added a way to handle and show form and field errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+{
+  "name": "CI",
+  "on": {
+    "push": {
+      "branches": [
+        "master"
+      ]
+    },
+    "pull_request": null,
+    "schedule": [
+      {
+        "cron": "0 10 * * 1"
+      }
+    ]
+  },
+  "jobs": {
+    "linter": {
+      "runs-on": "ubuntu-latest",
+      "env": {
+        "OS": "ubuntu-latest",
+        "QUICKLISP_DIST": "quicklisp",
+        "LISP": "sbcl-bin"
+      },
+      "steps": [
+        {
+          "name": "Checkout Code",
+          "uses": "actions/checkout@v1"
+        },
+        {
+          "name": "Grant All Perms to Make Cache Restoring Possible",
+          "run": "sudo mkdir -p /usr/local/etc/roswell\n                 sudo chown \"${USER}\" /usr/local/etc/roswell\n                 # Here the ros binary will be restored:\n                 sudo chown \"${USER}\" /usr/local/bin",
+          "shell": "bash"
+        },
+        {
+          "name": "Get Current Month",
+          "id": "current-month",
+          "run": "echo \"::set-output name=value::$(date -u \"+%Y-%m\")\"",
+          "shell": "bash"
+        },
+        {
+          "name": "Cache Roswell Setup",
+          "id": "cache",
+          "uses": "actions/cache@v2",
+          "with": {
+            "path": "qlfile\n                           qlfile.lock\n                           /usr/local/bin/ros\n                           ~/.cache/common-lisp/\n                           ~/.roswell\n                           /usr/local/etc/roswell\n                           .qlot",
+            "key": "${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-ubuntu-latest-quicklisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
+          }
+        },
+        {
+          "name": "Restore Path To Cached Files",
+          "run": "echo $HOME/.roswell/bin >> $GITHUB_PATH\n                 echo .qlot/bin >> $GITHUB_PATH",
+          "shell": "bash",
+          "if": "steps.cache.outputs.cache-hit == 'true'"
+        },
+        {
+          "name": "Setup Common Lisp Environment",
+          "uses": "40ants/setup-lisp@v1",
+          "with": {
+            "asdf-system": "weblocks-ui"
+          },
+          "if": "steps.cache.outputs.cache-hit != 'true'"
+        },
+        {
+          "name": "Install SBLint",
+          "run": "\necho 'dist ultralisp http://dist.ultralisp.org' > qlfile\nqlot update\nqlot exec ros install 40ants-linter\n",
+          "shell": "bash"
+        },
+        {
+          "name": "Run Linter",
+          "run": "qlot exec 40ants-linter --system \"weblocks-ui\"",
+          "shell": "bash"
+        }
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /docs/build/
 /env/
+/.qlot/

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,15 @@
  ChangeLog
 ===========
 
+0.11 (2021-06-02)
+=================
+
+Added a way to handle and show form and field errors.
+
+Use ``error-placeholder`` function and ``form-error-placeholder`` function
+inside the ``with-html-form`` macro. And signal errors using ``field-error``
+and ``form-error`` functions.
+
 0.10 (2021-01-07)
 =================
 

--- a/qlfile
+++ b/qlfile
@@ -1,0 +1,1 @@
+dist ultralisp http://dist.ultralisp.org

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -5,4 +5,4 @@
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org" :%version :latest)
-  :version "20210603123506"))
+  :version "20210603125008"))

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,0 +1,8 @@
+("quicklisp" .
+ (:class qlot/source/dist:source-dist
+  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
+  :version "2021-05-31"))
+("ultralisp" .
+ (:class qlot/source/dist:source-dist
+  :initargs (:distribution "http://dist.ultralisp.org" :%version :latest)
+  :version "20210603123506"))

--- a/src/ci.lisp
+++ b/src/ci.lisp
@@ -1,0 +1,28 @@
+(defpackage #:weblocks-ui/ci
+  (:use #:cl)
+  (:import-from #:40ants-ci/jobs/linter
+                #:linter)
+  (:import-from #:40ants-ci/jobs/run-tests
+                #:run-tests)
+  (:import-from #:40ants-ci/jobs/docs
+                #:build-docs)
+  (:import-from #:40ants-ci/workflow
+                #:defworkflow))
+(in-package weblocks-ui/ci)
+
+
+;; (defworkflow docs
+;;   :on-push-to "master"
+;;   :by-cron "0 10 * * 1"
+;;   :cache t
+;;   :jobs ((build-docs)))
+
+
+(defworkflow ci
+  :on-push-to "master"
+  :by-cron "0 10 * * 1"
+  :on-pull-request t
+  :cache t
+  :jobs ((linter)
+         ;; (run-tests :coverage t)
+         ))


### PR DESCRIPTION
Use `error-placeholder` function and `form-error-placeholder` function
inside the `with-html-form` macro. And signal errors using `field-error`
and `form-error` functions.